### PR TITLE
Remove `classmethod` from `async_check_api_key`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ from aiopurpleair import API
 
 async def main() -> None:
     """Run."""
-    response = await API.async_check_api_key("<API KEY>")
+    api = API("<API KEY>")
+    response = await api.async_check_api_key()
     # >>> response.api_key_type == ApiKeyType.READ
     # >>> response.api_version == "V1.0.11-0.0.41"
     # >>> response.timestamp_utc == datetime(2022, 10, 27, 18, 25, 41)

--- a/aiopurpleair/api.py
+++ b/aiopurpleair/api.py
@@ -40,21 +40,13 @@ class API:  # pylint: disable=too-few-public-methods
             self.async_request, self.async_request_with_response_model
         )
 
-    @classmethod
-    async def async_check_api_key(
-        cls, api_key: str, *, session: ClientSession | None = None
-    ) -> GetKeysResponse:
-        """Define a conveninece class method to check an API key.
-
-        Args:
-            api_key: The API key to check.
-            session: An optional aiohttp ClientSession.
+    async def async_check_api_key(self) -> GetKeysResponse:
+        """Check the validity of the API key.
 
         Returns:
             An API response payload.
         """
-        instance = cls(api_key, session=session)
-        return await instance.async_request_with_response_model(
+        return await self.async_request_with_response_model(
             "get", "/keys", GetKeysResponse
         )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -78,10 +78,11 @@ async def test_check_api_key(
 
     if use_session:
         async with aiohttp.ClientSession() as session:
-            response = await API.async_check_api_key(TEST_API_KEY, session=session)
+            api = API(TEST_API_KEY, session=session)
     else:
-        response = await API.async_check_api_key(TEST_API_KEY)
+        api = API(TEST_API_KEY)
 
+    response = await api.async_check_api_key()
     assert isinstance(response, GetKeysResponse)
     assert response.api_key_type == ApiKeyType.READ
     assert response.api_version == "V1.0.11-0.0.41"
@@ -109,7 +110,8 @@ async def test_check_api_key_validation_error(aresponses: ResponsesMockServer) -
 
     async with aiohttp.ClientSession() as session:
         with pytest.raises(RequestError) as err:
-            _ = await API.async_check_api_key(TEST_API_KEY, session=session)
+            api = API(TEST_API_KEY, session=session)
+            _ = await api.async_check_api_key()
         assert "FAKE is an unknown API key type" in str(err.value)
 
     aresponses.assert_plan_strictly_followed()


### PR DESCRIPTION
**Describe what the PR does:**

After starting the HASS integration, I realized the `@classmethod` version of `async_check_api_key` isn't terribly useful. This PR moves it to a standard method on an instantiated `API` object.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
