### PR TITLE
Add `NotFoundError` as an exception type

### DIFF
--- a/aiopurpleair/errors.py
+++ b/aiopurpleair/errors.py
@@ -13,6 +13,12 @@ class PurpleAirError(Exception):
     pass
 
 
+class NotFoundError(PurpleAirError):
+    """Define an unknown resource."""
+
+    pass
+
+
 class InvalidRequestError(PurpleAirError):
     """Define an invalid request."""
 
@@ -34,6 +40,7 @@ class InvalidApiKeyError(RequestError):
 ERROR_CODE_MAP = {
     "ApiKeyMissingError": InvalidApiKeyError,
     "ApiKeyInvalidError": InvalidApiKeyError,
+    "NotFoundError": NotFoundError,
 }
 
 

--- a/tests/fixtures/error_not_found_response.json
+++ b/tests/fixtures/error_not_found_response.json
@@ -1,0 +1,6 @@
+{
+  "api_version": "V1.0.11-0.0.41",
+  "time_stamp": 1669085063,
+  "error": "NotFoundError",
+  "description": "Cannot find a sensor with the provided parameters."
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,7 @@ import pytest
 from aresponses import ResponsesMockServer
 
 from aiopurpleair import API
-from aiopurpleair.errors import InvalidApiKeyError, RequestError
+from aiopurpleair.errors import InvalidApiKeyError, NotFoundError, RequestError
 from aiopurpleair.models.keys import ApiKeyType, GetKeysResponse
 from tests.common import TEST_API_KEY, load_fixture
 
@@ -20,6 +20,7 @@ from tests.common import TEST_API_KEY, load_fixture
     [
         ("error_invalid_api_key_response.json", InvalidApiKeyError, 403),
         ("error_missing_api_key_response.json", InvalidApiKeyError, 403),
+        ("error_not_found_response.json", NotFoundError, 404),
         ("error_unknown_response.json", RequestError, 500),
     ],
 )


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds a more specific exception type for the cases where we request a resource (such as a sensor by index) that can't be found.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
