### PR TITLE
Fix bug with `API.sensors.async_get_sensor` not resolving

### DIFF
--- a/aiopurpleair/endpoints/sensors.py
+++ b/aiopurpleair/endpoints/sensors.py
@@ -35,7 +35,7 @@ class SensorsEndpoints(APIEndpointsBase):
             An API response payload in the form of a Pydantic model.
         """
         response: GetSensorResponse = await self._async_endpoint_request_with_models(
-            f"/sensor/{sensor_index}",
+            f"/sensors/{sensor_index}",
             (
                 ("fields", fields),
                 ("read_key", read_key),

--- a/aiopurpleair/models/sensors.py
+++ b/aiopurpleair/models/sensors.py
@@ -348,7 +348,7 @@ class SensorModel(BaseModel):
 
 
 class GetSensorRequest(BaseModel):
-    """Define a request to GET /v1/sensor/:sensor_index."""
+    """Define a request to GET /v1/sensors/:sensor_index."""
 
     fields: Optional[list[str]] = None
     read_key: Optional[str] = None
@@ -365,7 +365,7 @@ class GetSensorRequest(BaseModel):
 
 
 class GetSensorResponse(BaseModel):
-    """Define a response to GET /v1/sensor/:sensor_index."""
+    """Define a response to GET /v1/sensors/:sensor_index."""
 
     api_version: str
     sensor: SensorModel

--- a/tests/endpoints/test_sensors.py
+++ b/tests/endpoints/test_sensors.py
@@ -56,14 +56,14 @@ async def test_get_nearby_sensor_indicies(
 async def test_get_sensor(  # pylint: disable=too-many-statements
     aresponses: ResponsesMockServer,
 ) -> None:
-    """Test the GET /sensor/:sensor_index endpoint.
+    """Test the GET /sensors/:sensor_index endpoint.
 
     Args:
         aresponses: An aresponses server.
     """
     aresponses.add(
         "api.purpleair.com",
-        "/v1/sensor/12345",
+        "/v1/sensors/12345",
         "get",
         response=aiohttp.web_response.json_response(
             json.loads(load_fixture("get_sensor_response.json")), status=200
@@ -203,7 +203,7 @@ async def test_get_sensor(  # pylint: disable=too-many-statements
 
 @pytest.mark.asyncio
 async def test_get_sensor_validation_error(aresponses: ResponsesMockServer) -> None:
-    """Test the GET /sensor/:sensor_index endpoint, returning a validation error.
+    """Test the GET /sensors/:sensor_index endpoint, returning a validation error.
 
     Args:
         aresponses: An aresponses server.


### PR DESCRIPTION
**Describe what the PR does:**

We were looking at the wrong endpoint (`/v1/sensor/:sensor_index` when it should be `/v1/sensors/:sensor_index`).

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
