### PR TITLE
Alter response payload for `API.sensors.async_get_nearby_sensors`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-- `fields` (required): The sensor data fields to include.
-- `location_type` (optional): An LocationType to filter by.
-- `max_age` (optional): Filter results modified within these seconds.
-- `modified_since` (optional): Filter results modified since a UTC datetime.
-- `read_keys` (optional): Read keys for private sensors.
-- `sensor_indices` (optional): Filter results by sensor index.
+- `fields` (required): The sensor data fields to include
+- `location_type` (optional): An LocationType to filter by
+- `max_age` (optional): Filter results modified within these seconds
+- `modified_since` (optional): Filter results modified since a UTC datetime
+- `read_keys` (optional): Read keys for private sensors
+- `sensor_indices` (optional): Filter results by sensor index
 
 ## Getting a Single Sensor
 
@@ -126,9 +126,9 @@ asyncio.run(main())
 
 ## Getting Nearby Sensors
 
-This method returns a list of `SensorModel` objects that are within a bounding box around
-a given latitude/longitude pair. The list is sorted from nearest to furthest (i.e., the
-first index in the list is the closest to the latitude/longitude).
+This method returns a list of `NearbySensorResult` objects that are within a bounding box
+around a given latitude/longitude pair. The list is sorted from nearest to furthest
+(i.e., the first index in the list is the closest to the latitude/longitude).
 
 ```python
 import asyncio
@@ -142,17 +142,23 @@ async def main() -> None:
     sensors = await api.sensors.async_get_nearby_sensors(
         ["name"], 51.5285582, -0.2416796, 10
     )
-    # >>> [SensorModel(...), SensorModel(...)]
+    # >>> [NearbySensorResult(...), NearbySensorResult(...)]
 
 
 asyncio.run(main())
 ```
 
-- `fields` (required): The sensor data fields to include.
-- `latitude` (required): The latitude of the point to measure distance from.
-- `longitude` (required): The longitude of the point to measure distance from.
-- `distance` (required): The distance from the measured point to search (in kilometers).
-- `limit` (optional): Limit the results.
+`NearbySensorResult` objects have two properties:
+
+- `sensor`: the corresponding `SensorModel` object
+- `distance`: the calculated distance (in kilometers) between this sensor and the provided
+  latitude/longitude
+
+- `fields` (required): The sensor data fields to include
+- `latitude` (required): The latitude of the point to measure distance from
+- `longitude` (required): The longitude of the point to measure distance from
+- `distance` (required): The distance from the measured point to search (in kilometers)
+- `limit` (optional): Limit the results
 
 ## Connection Pooling
 

--- a/tests/endpoints/test_sensors.py
+++ b/tests/endpoints/test_sensors.py
@@ -10,6 +10,7 @@ from aresponses import ResponsesMockServer
 
 from aiopurpleair import API
 from aiopurpleair.const import ChannelFlag, ChannelState, LocationType
+from aiopurpleair.endpoints.sensors import NearbySensorResult
 from aiopurpleair.errors import InvalidRequestError
 from aiopurpleair.models.sensors import SensorModel
 from tests.common import TEST_API_KEY, load_fixture
@@ -22,51 +23,66 @@ from tests.common import TEST_API_KEY, load_fixture
         (
             None,
             [
-                SensorModel(
-                    **{
-                        "sensor_index": 131077,
-                        "name": "BEE Patio",
-                        "latitude": 37.93273,
-                        "longitude": -122.03972,
-                    }
+                NearbySensorResult(
+                    sensor=SensorModel(
+                        **{
+                            "sensor_index": 131077,
+                            "name": "BEE Patio",
+                            "latitude": 37.93273,
+                            "longitude": -122.03972,
+                        }
+                    ),
+                    distance=2.2331696896024913,
                 ),
-                SensorModel(
-                    **{
-                        "sensor_index": 131079,
-                        "name": "BRSKBV-outside",
-                        "latitude": 37.75315,
-                        "longitude": -122.44364,
-                    }
+                NearbySensorResult(
+                    sensor=SensorModel(
+                        **{
+                            "sensor_index": 131079,
+                            "name": "BRSKBV-outside",
+                            "latitude": 37.75315,
+                            "longitude": -122.44364,
+                        }
+                    ),
+                    distance=41.766579532099314,
                 ),
-                SensorModel(
-                    **{
-                        "sensor_index": 131083,
-                        "name": "Test Sensor",
-                        "latitude": 38.287594,
-                        "longitude": -122.46281,
-                    }
+                NearbySensorResult(
+                    sensor=SensorModel(
+                        **{
+                            "sensor_index": 131083,
+                            "name": "Test Sensor",
+                            "latitude": 38.287594,
+                            "longitude": -122.46281,
+                        }
+                    ),
+                    distance=56.35082086588817,
                 ),
-                SensorModel(
-                    **{
-                        "sensor_index": 131075,
-                        "name": "Mariners Bluff",
-                        "latitude": 33.51511,
-                        "longitude": -117.67972,
-                    }
+                NearbySensorResult(
+                    sensor=SensorModel(
+                        **{
+                            "sensor_index": 131075,
+                            "name": "Mariners Bluff",
+                            "latitude": 33.51511,
+                            "longitude": -117.67972,
+                        }
+                    ),
+                    distance=627.8171580436522,
                 ),
             ],
         ),
         (
             1,
             [
-                SensorModel(
-                    **{
-                        "sensor_index": 131077,
-                        "name": "BEE Patio",
-                        "latitude": 37.93273,
-                        "longitude": -122.03972,
-                    }
-                )
+                NearbySensorResult(
+                    sensor=SensorModel(
+                        **{
+                            "sensor_index": 131077,
+                            "name": "BEE Patio",
+                            "latitude": 37.93273,
+                            "longitude": -122.03972,
+                        }
+                    ),
+                    distance=2.2331696896024913,
+                ),
             ],
         ),
     ],
@@ -74,7 +90,7 @@ from tests.common import TEST_API_KEY, load_fixture
 async def test_get_nearby_sensors(
     aresponses: ResponsesMockServer,
     limit_results: int | None,
-    output: list[SensorModel],
+    output: list[NearbySensorResult],
 ) -> None:
     """Test getting sensor indices within a bounding box around a latitude/longitude.
 


### PR DESCRIPTION
**Describe what the PR does:**

During the implementation of the Home Assistant integration, I found a situation where it'd be useful for the results of `API.sensors.async_get_nearby_sensors` to return the `SensorModel` objects _and_ the calculated distance for each.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
