### PR TITLE
Fix pytest warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,3 +156,7 @@ include = ["aiopurpleair"]
 min_confidence = 80
 paths = ["aiopurpleair", "tests"]
 verbose = false
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
**Describe what the PR does:**  
Fix pytest warnings.

**Does this fix a specific issue?**

```log
vscode ➜ /workspaces/bachya-aiopurpleair (precommit) $ poetry run pytest --cov -vv aiopurpleair tests
/home/vscode/.cache/pypoetry/virtualenvs/aiopurpleair-ewUDEtOB-py3.12/lib/python3.12/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
```

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
